### PR TITLE
Hashの確認をスキップ

### DIFF
--- a/lib/trailblazer/finder/base.rb
+++ b/lib/trailblazer/finder/base.rb
@@ -25,13 +25,11 @@ module Trailblazer
 
       def fetch_result
         result = @find.query self
-        result = Utils::Array.convert_hashes_in_array_to_struct(result) if result.first.is_a?(Hash)
         result
       end
 
       def fetch_result_all
         result = @find.query_all self
-        result = Utils::Array.convert_hashes_in_array_to_struct(result) if result.first.is_a?(Hash)
         result
       end
     end


### PR DESCRIPTION
# これは何？
`result.first`の処理が余分なクエリを発行してしまっていたので、削除してみてアプリの挙動に
影響があるかどうか様子見する！

→ 問題なさそうなのでマージ